### PR TITLE
installer: Fix error handling. Add Windows 11 support.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,14 +11,18 @@ To build dll and Launcher:
 - `./build.sh` - Requires DirectX June 2010, MSBuild, Visual Studio 2019 and Git Bash.
 
 To build the installer:
-- `VERSION=X.X.X ./package.sh` - Expects a version to be provided by setting an environment variable. Saves and builds artifacts to `build/`. Requires Inno Setup and Git Bash.
+- `VERSION=X.X.X ./package.sh` - Expects a version to be provided by setting an environment variable. Saves and builds artifacts to `build/`. Requires Golang, Inno Setup, and Git Bash.
 
 ## Troubleshooting
+
 - `%localappdata%\Temp` - Installer logs are saved in here. E.g., `Setup Log 2023-07-13 #010.txt`
+  and `mirrors-edge-multiplayer-installer-helper-*.log`
 - `Get-MpThreatDetection` - Run this command in Windows PowerShell to get Windows Defender threat history to see if any of the multiplayer files were affected. 
 
 ## Contributors
+
 Thanks to these wonderful people :)
+
 - [btbd](https://github.com/btbd)
 - [LucasOe](https://github.com/LucasOe)
 - [Toyro98](https://github.com/Toyro98)

--- a/resources/installer/squibbles/main.go
+++ b/resources/installer/squibbles/main.go
@@ -1,12 +1,17 @@
-// Application that helps evade Windows Defender by XORing launcher and dll and
-// extracting files at install time.
+// Application that helps evade Windows Defender by adding a Windows
+// Defender exclusion and XORing launcher and dll prior to extracting
+// those files at install-time.
 package main
 
 import (
+	"context"
 	_ "embed"
+	"flag"
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
+	"os/signal"
 	"path/filepath"
 )
 
@@ -19,21 +24,96 @@ var (
 )
 
 func main() {
-	log.SetFlags(0)
+	var logF *os.File
+
+	// Create a log file if a debug env. is not specified.
+	if os.Getenv("SQUIBBLES_DEBUG_NO_LOG") != "true" {
+		// Note: '*' is replaced with a random number.
+		logF, _ = os.CreateTemp("", "mirrors-edge-multiplayer-installer-helper-*.log")
+		if logF != nil {
+			log.SetOutput(logF)
+		}
+	}
+
+	exitCode := 0
 
 	err := mainWithError()
 	if err != nil {
-		log.Fatalln("error:", err)
+		log.Println("fatal:", err)
+		exitCode = 1
 	}
+
+	if logF != nil {
+		_ = logF.Sync()
+		_ = logF.Close()
+	}
+
+	os.Exit(exitCode)
 }
 
 func mainWithError() error {
+	flag.Parse()
+
+	ctx, cancelFn := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancelFn()
+
+	switch flag.Arg(0) {
+	case "install":
+		return install(ctx)
+	case "uninstall":
+		return uninstall(ctx)
+	default:
+		return fmt.Errorf("unknown non-flag argument: '%s'", flag.Arg(0))
+	}
+}
+
+func install(ctx context.Context) error {
 	exePath, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("failed to get file path - %w", err)
+		return fmt.Errorf("failed to get exe path - %w", err)
 	}
 
 	parentDirectory := filepath.Dir(exePath)
+
+	// Windows Defender does not like how the launcher
+	// does process injection (it may also dislike the
+	// client dll for unknown reasons). The long-term
+	// soltuion for this is to modify the launcher's
+	// process injection behavior to not make Defender
+	// angy. For now, we are opting to add a Defender
+	// exclusion for the "bin" directory.
+	//
+	// While sub-optimal, a Defender exclsuion should
+	// be safe because the installer writes the files
+	// to a directory that only Windows Administrators
+	// can write to. This means malware and other
+	// unsavory programs cannot abuse our exclusion
+	// to hide from Defender.
+	//
+	// We do this in squibbles instead of in the installer
+	// because Windows 11's Defender appears to test for
+	// this behavior (it is unclear how it actually
+	// detects it). This does not appear to be the
+	// case on Windows 10.
+	//
+	// Note: The extra double quotes around the parent
+	// directory are required. Without these quotes,
+	// the string will be malformed if a single quote
+	// is present in the directory path. This is some
+	// terrible Windows garbage where each process
+	// handles argv differently (rather than it being
+	// an array that is passed to the process like
+	// a sane operating system would do).
+	output, err := exec.CommandContext(ctx,
+		`C:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe`,
+		"Add-MpPreference",
+		"-ExclusionPath",
+		`"`+parentDirectory+`"`).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to add windows defender exclusion for '%s' - output: '%s' - %w",
+			parentDirectory, output, err)
+	}
+
 	launcherF, err := os.OpenFile(filepath.Join(parentDirectory, "Launcher.exe"), os.O_CREATE|os.O_WRONLY, 0755)
 	if err != nil {
 		return fmt.Errorf("cannot open launcher - %w", err)
@@ -58,6 +138,31 @@ func mainWithError() error {
 		if err != nil {
 			return fmt.Errorf("failed to write to dll - %w", err)
 		}
+	}
+
+	return nil
+}
+
+func uninstall(ctx context.Context) error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get exe path - %w", err)
+	}
+
+	parentDirectory := filepath.Dir(exePath)
+
+	// Note: The extra double quotes around the parent
+	// directory are required. Without these quotes,
+	// the string will be malformed if a single quote
+	// is present in the directory path.
+	output, err := exec.CommandContext(ctx,
+		`C:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe`,
+		"Remove-MpPreference",
+		"-ExclusionPath",
+		`"`+parentDirectory+`"`).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to remove windows defender exclusion for '%s' - output: '%s' - %w",
+			parentDirectory, output, err)
 	}
 
 	return nil


### PR DESCRIPTION
This commit addresses several issues:

- Windows 11's implementation of Defender appears to care about adding an exclusion. @SeungKang noticed this on one of her Windows 11 machines. From the end-user's perspective, they would download the installer from GitHub and Defender would immediately block it without the user executing it. We identified the issue by re-building the installer without the "Add-MpPreference" execution and found that Windows was happy. The "fix" for this issue was to move the exclusion add / removal logic into squibbles. Defender does not appear to notice this. This was originally meant to be a short-term fix until we can identify a less-malware-y process injection technique
- Fixed InnoSetup's broken error handling for "Run" section programs. @SeungKang and I noticed that "Run" was not honoring exit statuses of the processes it executes. Since we are dealing with installer issues, I decided it was worth improving. With this commit, the installer will fail if squibbles exits with a non-zero exit status. This work is based off of Martin Prikryl's work (included in the code comments)
- Create a log file for squibbles in the temp directory

@SeungKang and I tested these changes on both Windows 10 and 11.